### PR TITLE
fix: prevent the instance from calling n8n servers

### DIFF
--- a/terraform/aws/alarms.tf
+++ b/terraform/aws/alarms.tf
@@ -6,7 +6,10 @@ locals {
     "Exception",
     "exception",
   ]
-  n8n_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.n8n_error_filters)}*\")]"
+  n8n_error_skip = [
+    "Troubleshooting URL",
+  ]
+  n8n_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.n8n_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.n8n_error_skip)}*\"]"
 }
 
 #

--- a/terraform/aws/ecs.tf
+++ b/terraform/aws/ecs.tf
@@ -1,6 +1,18 @@
 locals {
   container_env = [
     {
+      "name"  = "EXTERNAL_FRONTEND_HOOKS_URLS",
+      "value" = ""
+    },
+    {
+      "name"  = "N8N_DIAGNOSTICS_CONFIG_FRONTEND"
+      "value" = ""
+    },
+    {
+      "name"  = "N8N_DIAGNOSTICS_CONFIG_BACKEND"
+      "value" = ""
+    },
+    {
       "name"  = "N8N_DIAGNOSTICS_ENABLED"
       "value" = "false"
     },
@@ -19,6 +31,10 @@ locals {
     {
       "name"  = "N8N_HOST"
       "value" = var.domain
+    },
+    {
+      "name"  = "N8N_LOG_LEVEL"
+      "value" = "debug"
     },
     {
       "name"  = "N8N_PERSONALIZATION_ENABLED"
@@ -41,8 +57,20 @@ locals {
       "value" = "true"
     },
     {
+      "name"  = "N8N_TEMPLATES_ENABLED"
+      "value" = "false"
+    },
+    {
       "name"  = "NODE_ENV"
       "value" = "production"
+    },
+    {
+      "name"  = "QUEUE_HEALTH_CHECK_ACTIVE"
+      "value" = "true"
+    },
+    {
+      "name"  = "N8N_VERSION_CHECK_ENABLED"
+      "value" = "false"
     },
     {
       "name"  = "WEBHOOK_URL"

--- a/terraform/aws/load_balancer.tf
+++ b/terraform/aws/load_balancer.tf
@@ -37,8 +37,8 @@ resource "aws_lb_target_group" "n8n" {
   health_check {
     enabled  = true
     protocol = "HTTP"
-    path     = "/"
-    matcher  = "200-399"
+    path     = "/healthz/readiness"
+    matcher  = "200"
   }
 
   stickiness {


### PR DESCRIPTION
# Summary
Update the config of the instance so that it no longer connects
to n8n servers.

Additionally enables the health check endpoint and increases the
logging level to debug.