### PR TITLE
chore: suppress more false positive errors

### DIFF
--- a/terraform/aws/alarms.tf
+++ b/terraform/aws/alarms.tf
@@ -7,6 +7,7 @@ locals {
     "exception",
   ]
   n8n_error_skip = [
+    "Last session crashed",
     "Troubleshooting URL",
   ]
   n8n_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.n8n_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.n8n_error_skip)}*\"]"

--- a/terraform/aws/ecs.tf
+++ b/terraform/aws/ecs.tf
@@ -61,6 +61,10 @@ locals {
       "value" = "false"
     },
     {
+      "name"  = "NO_COLOR",
+      "value" = "true"
+    },
+    {
       "name"  = "NODE_ENV"
       "value" = "production"
     },


### PR DESCRIPTION
# Summary
Update the list of false-positive errors that should not trigger a CloudWatch alarm.  Also disable colours in the log output.
