### PR TITLE
feat: add a DNS resolver firewall

### DIFF
--- a/terraform/aws/route53.tf
+++ b/terraform/aws/route53.tf
@@ -14,3 +14,19 @@ resource "aws_route53_record" "n8n_A" {
     evaluate_target_health = false
   }
 }
+
+#
+# Add a DNS resolver firewall to limit outbound DNS queries
+#
+module "resolver_dns" {
+  source           = "github.com/cds-snc/terraform-modules//resolver_dns?ref=v10.5.2"
+  vpc_id           = module.vpc.vpc_id
+  firewall_enabled = true
+
+  allowed_domains = [
+    "*.amazonaws.com.",
+    "*.azure.com.",
+  ]
+
+  billing_tag_value = var.billing_code
+}


### PR DESCRIPTION
# Summary
Add a firewall that limits the domains that the VPC's DNS resolver will lookup.