### PR TITLE
chore: add GC domains to DNS firewall

### DIFF
--- a/terraform/aws/route53.tf
+++ b/terraform/aws/route53.tf
@@ -27,6 +27,10 @@ module "resolver_dns" {
     "*.amazonaws.com.",      # AWS
     "*.azure.com.",          # Azure OpenAI
     "*.azure-api.net.",      # Azure OpenAI
+    "*.canada.ca.",          # Government of Canada
+    "*.cds-snc.ca.",         # Government of Canada
+    "*.cdssandbox.xyz.",     # Government of Canada
+    "*.gc.ca.",              # Government of Canada
     "*.microsoft.com.",      # Azure OpenAI
     "*.trafficmanager.net.", # Azure OpenAI
     "tiktoken.pages.dev.",   # OpenAI token counting


### PR DESCRIPTION
# Summary
Allow n8n to talk out to Government of Canada domains.
