### PR TITLE
chore: suppress failed n8n.io lookups

### DIFF
--- a/terraform/aws/alarms.tf
+++ b/terraform/aws/alarms.tf
@@ -7,6 +7,7 @@ locals {
     "exception",
   ]
   n8n_error_skip = [
+    "ENOTFOUND api.n8n.io",
     "Last session crashed",
     "Troubleshooting URL",
   ]


### PR DESCRIPTION
# Summary
`n8n.io` is blocked by the DNS firewall so we can safely suppress this error.
