### PR TITLE
feat: add self-hosted model in n8n ECS cluster

### DIFF
--- a/terraform/aws/alarms.tf
+++ b/terraform/aws/alarms.tf
@@ -1,15 +1,18 @@
 locals {
   n8n_error_filters = [
-    "ERROR",
-    "Error",
     "error",
-    "Exception",
-    "exception",
   ]
   n8n_error_skip = [
     "ENOTFOUND api.n8n.io",
+    "Invalid URL",
     "Last session crashed",
+    "Node does not have any credentials set",
+    "Received request for unknown webhook",
+    "Running node * finished with error",
+    "The workflow has issues",
+    "This will become an error in a future version of the SDK",
     "Troubleshooting URL",
+    "Workflow execution finished with error",
   ]
   n8n_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.n8n_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.n8n_error_skip)}*\"]"
 }
@@ -187,6 +190,7 @@ resource "aws_cloudwatch_query_definition" "n8n_ecs_errors" {
   query_string = <<-QUERY
     fields @timestamp, @message, @logStream
     | filter @message like /${join("|", local.n8n_error_filters)}/
+    | filter @message not like /${join("|", local.n8n_error_skip)}/
     | sort @timestamp desc
     | limit 100
   QUERY

--- a/terraform/aws/route53.tf
+++ b/terraform/aws/route53.tf
@@ -38,6 +38,9 @@ module "resolver_dns" {
     "*.microsoft.com.",         # Azure OpenAI
     "*.trafficmanager.net.",    # Azure OpenAI
     "tiktoken.pages.dev.",      # OpenAI token counting
+    "*.docker.com.",            # Docker Hub
+    "*.docker.io.",             # Docker Hub
+    "*.n8n.ecs.local.",         # Service discovery for n8n
   ]
 
   billing_tag_value = var.billing_code

--- a/terraform/aws/route53.tf
+++ b/terraform/aws/route53.tf
@@ -24,16 +24,20 @@ module "resolver_dns" {
   firewall_enabled = true
 
   allowed_domains = [
-    "*.amazonaws.com.",      # AWS
-    "*.azure.com.",          # Azure OpenAI
-    "*.azure-api.net.",      # Azure OpenAI
-    "*.canada.ca.",          # Government of Canada
-    "*.cds-snc.ca.",         # Government of Canada
-    "*.cdssandbox.xyz.",     # Government of Canada
-    "*.gc.ca.",              # Government of Canada
-    "*.microsoft.com.",      # Azure OpenAI
-    "*.trafficmanager.net.", # Azure OpenAI
-    "tiktoken.pages.dev.",   # OpenAI token counting
+    "*.amazonaws.com.",         # AWS
+    "*.azure.com.",             # Azure OpenAI
+    "*.azure-api.net.",         # Azure OpenAI
+    "canada.ca.",               # Government of Canada
+    "*.canada.ca.",             # Government of Canada
+    "*.cds-snc.ca.",            # Government of Canada
+    "*.cdssandbox.xyz.",        # Government of Canada
+    "*.gc.ca.",                 # Government of Canada
+    "github.com.",              # GitHub
+    "*.github.com.",            # GitHub
+    "*.githubusercontent.com.", # GitHub
+    "*.microsoft.com.",         # Azure OpenAI
+    "*.trafficmanager.net.",    # Azure OpenAI
+    "tiktoken.pages.dev.",      # OpenAI token counting
   ]
 
   billing_tag_value = var.billing_code

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -30,6 +30,11 @@ variable "env" {
   type        = string
 }
 
+variable "model_container_image" {
+  description = "Model's Docker image and tag."
+  type        = string
+}
+
 variable "region" {
   description = "AWS region."
   type        = string

--- a/terraform/aws/vpc.tf
+++ b/terraform/aws/vpc.tf
@@ -18,7 +18,7 @@ module "vpc" {
 # Security groups
 #
 
-# ECS
+# ECS n8n
 resource "aws_security_group" "n8n_ecs" {
   description = "NSG for n8n ECS Tasks"
   name        = "n8n_ecs"
@@ -46,6 +46,16 @@ resource "aws_security_group_rule" "n8n_ecs_egress_rds" {
   security_group_id        = aws_security_group.n8n_ecs.id
 }
 
+resource "aws_security_group_rule" "n8n_ecs_egress_model" {
+  description              = "Egress from n8n to model ECS task"
+  type                     = "egress"
+  from_port                = 11434
+  to_port                  = 11434
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.n8n_ecs.id
+  source_security_group_id = aws_security_group.model_ecs.id
+}
+
 resource "aws_security_group_rule" "n8n_ecs_ingress_lb" {
   description              = "Ingress from load balancer to n8n ECS task"
   type                     = "ingress"
@@ -54,6 +64,24 @@ resource "aws_security_group_rule" "n8n_ecs_ingress_lb" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.n8n_ecs.id
   source_security_group_id = aws_security_group.n8n_lb.id
+}
+
+# ECS model
+resource "aws_security_group" "model_ecs" {
+  description = "NSG for model ECS Tasks"
+  name        = "model_ecs"
+  vpc_id      = module.vpc.vpc_id
+  tags        = local.common_tags
+}
+
+resource "aws_security_group_rule" "model_ecs_ingress_n8n" {
+  description              = "Ingress from n8n to model ECS task"
+  type                     = "ingress"
+  from_port                = 11434
+  to_port                  = 11434
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.model_ecs.id
+  source_security_group_id = aws_security_group.n8n_ecs.id
 }
 
 # Load balancer

--- a/terraform/aws/waf.tf
+++ b/terraform/aws/waf.tf
@@ -118,7 +118,13 @@ resource "aws_wafv2_web_acl" "n8n" {
     statement {
       rate_based_statement {
         limit              = 1000
-        aggregate_key_type = "IP"
+        aggregate_key_type = "CUSTOM_KEYS"
+
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "MATCH"
+          }
+        }
       }
     }
 
@@ -140,7 +146,14 @@ resource "aws_wafv2_web_acl" "n8n" {
     statement {
       rate_based_statement {
         limit              = 200
-        aggregate_key_type = "IP"
+        aggregate_key_type = "CUSTOM_KEYS"
+
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "MATCH"
+          }
+        }
+
         scope_down_statement {
           regex_match_statement {
             field_to_match {
@@ -174,7 +187,14 @@ resource "aws_wafv2_web_acl" "n8n" {
     statement {
       rate_based_statement {
         limit              = 10
-        aggregate_key_type = "IP"
+        aggregate_key_type = "CUSTOM_KEYS"
+
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "MATCH"
+          }
+        }
+
         scope_down_statement {
           and_statement {
             statement {

--- a/terraform/env/staging/terragrunt.hcl
+++ b/terraform/env/staging/terragrunt.hcl
@@ -7,5 +7,6 @@ include {
 }
 
 inputs = {
-  n8n_container_image = "n8nio/n8n:1.99.1@sha256:2537366a01590c499a4f2c9006da55cdda4c572fd2765a99f5687187ae1cd4be"
+  n8n_container_image   = "n8nio/n8n:1.99.1@sha256:2537366a01590c499a4f2c9006da55cdda4c572fd2765a99f5687187ae1cd4be"
+  model_container_image = "ollama/ollama:0.9.3@sha256:45008241d61056449dd4f20cebf64bfa5a2168b0c078ecf34aa2779760502c2f"
 }


### PR DESCRIPTION
# Summary
Adds an ECS service that runs a self hosted model using [Ollama](https://ollama.com/).  To improve security, the following steps have been taken:

- The Ollama task does not include any LLMs initially.  They must be pulled after the service has started.
- The task does not have internet connectivity (after initial model pull) and can only communicate directly with the n8n ECS task via service discovery (private IP).


Additionally, this PR has the following fixes:

- Update the CloudWatch alarms to reduce false-positives from user errors.
- Update the WAF rules to allow testing of partial workflow executions.

# Related
- https://github.com/cds-snc/platform-core-services/issues/782