### PR TITLE
chore: update n8n to 1.104.2

### DIFF
--- a/terraform/aws/ecs.tf
+++ b/terraform/aws/ecs.tf
@@ -154,6 +154,8 @@ module "n8n_ecs" {
 }
 
 module "model_ecs" {
+  count = 0 # Remove for now as the testing is complete
+
   source = "github.com/cds-snc/terraform-modules//ecs?ref=v10.6.2"
 
   create_cluster   = false

--- a/terraform/env/staging/terragrunt.hcl
+++ b/terraform/env/staging/terragrunt.hcl
@@ -7,6 +7,6 @@ include {
 }
 
 inputs = {
-  n8n_container_image   = "n8nio/n8n:1.99.1@sha256:2537366a01590c499a4f2c9006da55cdda4c572fd2765a99f5687187ae1cd4be"
+  n8n_container_image   = "n8nio/n8n:1.104.2@sha256:4a475a6fdeb929f1070031d9ebfc49414d1e450886c6d000e5f6b432ebe4b8b6"
   model_container_image = "ollama/ollama:0.9.3@sha256:45008241d61056449dd4f20cebf64bfa5a2168b0c078ecf34aa2779760502c2f"
 }


### PR DESCRIPTION
# Summary
Update n8n and remove the ollama ECS model service.  It has been scaled down to 0 for several weeks but this will remove it completely in a way that is easy to recreate if needed.