### PR TITLE
fix: add Renovate custom matcher to update Terraform Docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cds-snc/renovate-config"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/|\\.)terragrunt.hcl$/"],
+      "matchStrings": [
+        "\\s*n8n_container_image\\s*=\\s*\"(?<currentValue>.*?)\"\\n",
+        "\\s*model_container_image\\s*=\\s*\"(?<currentValue>.*?)\"\\n"
+      ],
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
# Summary
Update the Renovate config with a custom matcher so that the Docker image tags in the `terragrunt.hcl` files are updated.
