### PR TITLE
fix: add missing DNS firewall entries

### DIFF
--- a/.github/workflows/terraform-apply-staging.yml
+++ b/.github/workflows/terraform-apply-staging.yml
@@ -52,3 +52,7 @@ jobs:
       - name: Apply Terraform
         working-directory: terraform/env/staging
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Wait for ECS services to stabilize
+        run: |
+          aws ecs wait services-stable --cluster n8n --services n8n --region $AWS_REGION

--- a/terraform/aws/route53.tf
+++ b/terraform/aws/route53.tf
@@ -24,25 +24,25 @@ module "resolver_dns" {
   firewall_enabled = true
 
   allowed_domains = [
-    "*.amazonaws.com.",         # AWS
-    "*.compute.internal.",      # AWS
-    "*.azure.com.",             # Azure OpenAI
-    "*.azure-api.net.",         # Azure OpenAI
-    "canada.ca.",               # Government of Canada
-    "*.canada.ca.",             # Government of Canada
-    "*.cds-snc.ca.",            # Government of Canada
-    "*.cdssandbox.xyz.",        # Government of Canada
-    "*.gc.ca.",                 # Government of Canada
-    "github.com.",              # GitHub
-    "*.github.com.",            # GitHub
-    "*.githubusercontent.com.", # GitHub
-    "*.microsoft.com.",         # Azure OpenAI
-    "*.trafficmanager.net.",    # Azure OpenAI
-    "tiktoken.pages.dev.",      # OpenAI token counting
-    "*.docker.com.",            # Docker Hub
-    "*.docker.io.",             # Docker Hub
+    "*.amazonaws.com.",                   # AWS
+    "*.compute.internal.",                # AWS
+    "*.azure.com.",                       # Azure OpenAI
+    "*.azure-api.net.",                   # Azure OpenAI
+    "canada.ca.",                         # Government of Canada
+    "*.canada.ca.",                       # Government of Canada
+    "*.cds-snc.ca.",                      # Government of Canada
+    "*.cdssandbox.xyz.",                  # Government of Canada
+    "*.gc.ca.",                           # Government of Canada
+    "github.com.",                        # GitHub
+    "*.github.com.",                      # GitHub
+    "*.githubusercontent.com.",           # GitHub
+    "*.microsoft.com.",                   # Azure OpenAI
+    "*.trafficmanager.net.",              # Azure OpenAI
+    "tiktoken.pages.dev.",                # OpenAI token counting
+    "*.docker.com.",                      # Docker Hub
+    "*.docker.io.",                       # Docker Hub
     "auth.docker.io.cdn.cloudflare.net.", # Docker Hub
-    "*.n8n.ecs.local.",         # Service discovery for n8n
+    "*.n8n.ecs.local.",                   # Service discovery for n8n
   ]
 
   billing_tag_value = var.billing_code

--- a/terraform/aws/route53.tf
+++ b/terraform/aws/route53.tf
@@ -25,6 +25,7 @@ module "resolver_dns" {
 
   allowed_domains = [
     "*.amazonaws.com.",         # AWS
+    "*.compute.internal.",      # AWS
     "*.azure.com.",             # Azure OpenAI
     "*.azure-api.net.",         # Azure OpenAI
     "canada.ca.",               # Government of Canada
@@ -40,6 +41,7 @@ module "resolver_dns" {
     "tiktoken.pages.dev.",      # OpenAI token counting
     "*.docker.com.",            # Docker Hub
     "*.docker.io.",             # Docker Hub
+    "auth.docker.io.cdn.cloudflare.net.", # Docker Hub
     "*.n8n.ecs.local.",         # Service discovery for n8n
   ]
 


### PR DESCRIPTION
# Summary
Update the DNS firewall with new entries required to pull Docker images.

Also add a step to the TF apply workflow to wait for the `n8n` deployment to finish.
